### PR TITLE
Implement Segnalazione screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,8 @@ dependencies {
 
     implementation("androidx.core:core-ktx:1.10.1")
     implementation("androidx.activity:activity-compose:1.7.2")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
     implementation("androidx.compose.ui:ui:1.5.1")
     implementation("androidx.compose.ui:ui-tooling-preview:1.5.1")
     implementation("androidx.compose.material3:material3:1.1.0")

--- a/app/src/main/java/it/quartierevivo/MainActivity.kt
+++ b/app/src/main/java/it/quartierevivo/MainActivity.kt
@@ -9,13 +9,14 @@ import it.quartierevivo.ui.theme.QuartiereVivoTheme
 
 class MainActivity : ComponentActivity() {
     private val viewModel: MainViewModel by viewModels()
+    private val segnalazioneViewModel: SegnalazioneViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             QuartiereVivoTheme {
                 Surface {
-                    // TODO add screens
+                    SegnalazioneScreen(segnalazioneViewModel)
                 }
             }
         }

--- a/app/src/main/java/it/quartierevivo/Segnalazione.kt
+++ b/app/src/main/java/it/quartierevivo/Segnalazione.kt
@@ -1,0 +1,11 @@
+package it.quartierevivo
+
+import android.net.Uri
+
+data class Segnalazione(
+    val titolo: String,
+    val descrizione: String,
+    val categoria: String,
+    val fotoUri: Uri?,
+    val posizione: String?
+)

--- a/app/src/main/java/it/quartierevivo/SegnalazioneScreen.kt
+++ b/app/src/main/java/it/quartierevivo/SegnalazioneScreen.kt
@@ -1,0 +1,131 @@
+package it.quartierevivo
+
+import android.Manifest
+import android.net.Uri
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SegnalazioneScreen(viewModel: SegnalazioneViewModel = viewModel()) {
+    val context = LocalContext.current
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val photoLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+        viewModel.onFotoChange(uri)
+    }
+
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        if (granted) {
+            photoLauncher.launch("image/*")
+        } else {
+            Toast.makeText(context, "Permesso fotocamera negato", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    val locationPermissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        if (granted) {
+            // Placeholder for real GPS retrieval
+            viewModel.onPosizioneChange("Lat:0, Lng:0")
+        } else {
+            Toast.makeText(context, "Permesso posizione negato", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    LaunchedEffect(viewModel.invioConfermato) {
+        if (viewModel.invioConfermato) {
+            snackbarHostState.showSnackbar("Segnalazione inviata")
+            viewModel.resetConferma()
+        }
+    }
+
+    var expanded by remember { mutableStateOf(false) }
+    val categorie = listOf("Manutenzione", "Sicurezza", "Altro")
+
+    Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            OutlinedTextField(
+                value = viewModel.titolo,
+                onValueChange = viewModel::onTitoloChange,
+                label = { Text("Titolo") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = viewModel.descrizione,
+                onValueChange = viewModel::onDescrizioneChange,
+                label = { Text("Descrizione") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            ExposedDropdownMenuBox(
+                expanded = expanded,
+                onExpandedChange = { expanded = !expanded }
+            ) {
+                OutlinedTextField(
+                    value = viewModel.categoria,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Categoria") },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                    modifier = Modifier.menuAnchor().fillMaxWidth()
+                )
+                androidx.compose.material3.ExposedDropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false }
+                ) {
+                    categorie.forEach { cat ->
+                        DropdownMenuItem(
+                            text = { Text(cat) },
+                            onClick = {
+                                viewModel.onCategoriaChange(cat)
+                                expanded = false
+                            }
+                        )
+                    }
+                }
+            }
+            Button(onClick = {
+                cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+            }) {
+                Text("Seleziona foto")
+            }
+            Button(onClick = {
+                locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+            }) {
+                Text("Ottieni posizione")
+            }
+            Button(onClick = { viewModel.inviaSegnalazione() }) {
+                Text("Invia")
+            }
+        }
+    }
+}

--- a/app/src/main/java/it/quartierevivo/SegnalazioneViewModel.kt
+++ b/app/src/main/java/it/quartierevivo/SegnalazioneViewModel.kt
@@ -1,0 +1,37 @@
+package it.quartierevivo
+
+import android.net.Uri
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+
+class SegnalazioneViewModel : ViewModel() {
+    var titolo by mutableStateOf("")
+        private set
+    var descrizione by mutableStateOf("")
+        private set
+    var categoria by mutableStateOf("")
+        private set
+    var fotoUri by mutableStateOf<Uri?>(null)
+        private set
+    var posizione by mutableStateOf<String?>(null)
+        private set
+    var invioConfermato by mutableStateOf(false)
+        private set
+
+    fun onTitoloChange(value: String) { titolo = value }
+    fun onDescrizioneChange(value: String) { descrizione = value }
+    fun onCategoriaChange(value: String) { categoria = value }
+    fun onFotoChange(uri: Uri?) { fotoUri = uri }
+    fun onPosizioneChange(value: String?) { posizione = value }
+
+    fun inviaSegnalazione() {
+        // Placeholder for actual send logic (e.g., Firebase)
+        invioConfermato = true
+    }
+
+    fun resetConferma() {
+        invioConfermato = false
+    }
+}


### PR DESCRIPTION
## Summary
- add ViewModel and data class for Segnalazione
- implement SegnalazioneScreen composable with permission handling and snackbar
- show SegnalazioneScreen from MainActivity
- add lifecycle dependencies

## Testing
- `gradle test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a1e892c4c83238258d720725dc63f