### PR TITLE
Aggiunge bottom sheet con dettagli delle segnalazioni

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,9 @@ dependencies {
     implementation("androidx.compose.ui:ui:1.5.1")
     implementation("androidx.compose.ui:ui-tooling-preview:1.5.1")
     implementation("androidx.compose.material3:material3:1.1.0")
+    implementation("com.google.android.gms:play-services-maps:18.1.0")
+    implementation("com.google.maps.android:maps-compose:6.6.0")
+    implementation("io.coil-kt:coil-compose:3.2.0")
 
     debugImplementation("androidx.compose.ui:ui-tooling:1.5.1")
 }

--- a/app/src/main/java/it/quartierevivo/DettaglioSegnalazioneSheet.kt
+++ b/app/src/main/java/it/quartierevivo/DettaglioSegnalazioneSheet.kt
@@ -1,0 +1,51 @@
+package it.quartierevivo
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+
+/**
+ * Bottom sheet con i dettagli di una segnalazione.
+ */
+@Composable
+fun DettaglioSegnalazioneSheet(
+    segnalazione: Segnalazione,
+    onChiudi: () -> Unit,
+    onSegnalaRisolta: () -> Unit = {}
+) {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(segnalazione.titolo, style = MaterialTheme.typography.titleMedium)
+        Text(segnalazione.descrizione)
+        Text("Categoria: ${segnalazione.categoria}")
+        segnalazione.fotoUri?.let { uri ->
+            AsyncImage(
+                model = uri,
+                contentDescription = null,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp)
+            )
+        }
+        Text("Inviata il ${segnalazione.dataInvio}")
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(onClick = onChiudi, modifier = Modifier.fillMaxWidth()) {
+            Text("Chiudi")
+        }
+        Button(onClick = onSegnalaRisolta, modifier = Modifier.fillMaxWidth()) {
+            Text("Segnala come risolta")
+        }
+    }
+}

--- a/app/src/main/java/it/quartierevivo/MappaSegnalazioniScreen.kt
+++ b/app/src/main/java/it/quartierevivo/MappaSegnalazioniScreen.kt
@@ -1,0 +1,48 @@
+package it.quartierevivo
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.rememberMarkerState
+
+/**
+ * Schermata che mostra le segnalazioni su mappa.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MappaSegnalazioniScreen(
+    viewModel: MappaSegnalazioniViewModel = viewModel()
+) {
+    val selected by viewModel.segnalazioneSelezionata
+
+    if (selected != null) {
+        ModalBottomSheet(onDismissRequest = viewModel::chiudiDettaglio) {
+            DettaglioSegnalazioneSheet(
+                segnalazione = selected!!,
+                onChiudi = viewModel::chiudiDettaglio,
+                onSegnalaRisolta = viewModel::segnalaRisolta
+            )
+        }
+    }
+
+    GoogleMap(modifier = Modifier.fillMaxSize()) {
+        viewModel.segnalazioni.forEach { segnalazione ->
+            segnalazione.posizione?.let { pos ->
+                Marker(
+                    state = rememberMarkerState(position = pos),
+                    title = segnalazione.titolo,
+                    onClick = {
+                        viewModel.onMarkerSelected(segnalazione)
+                        true
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/it/quartierevivo/MappaSegnalazioniViewModel.kt
+++ b/app/src/main/java/it/quartierevivo/MappaSegnalazioniViewModel.kt
@@ -1,0 +1,46 @@
+package it.quartierevivo
+
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import com.google.android.gms.maps.model.LatLng
+
+/**
+ * ViewModel per la schermata con la mappa delle segnalazioni.
+ */
+class MappaSegnalazioniViewModel : ViewModel() {
+
+    private val _segnalazioni = mutableStateListOf<Segnalazione>()
+    val segnalazioni: List<Segnalazione> get() = _segnalazioni
+
+    private val _segnalazioneSelezionata = mutableStateOf<Segnalazione?>(null)
+    val segnalazioneSelezionata: State<Segnalazione?> get() = _segnalazioneSelezionata
+
+    init {
+        // Dati di esempio
+        _segnalazioni += Segnalazione(
+            titolo = "Panchina rotta",
+            descrizione = "La panchina vicino al parco \u00e8 danneggiata.",
+            categoria = "Manutenzione",
+            fotoUri = null,
+            posizione = LatLng(41.0, 12.0),
+            dataInvio = "01/01/2024"
+        )
+    }
+
+    fun onMarkerSelected(segnalazione: Segnalazione) {
+        _segnalazioneSelezionata.value = segnalazione
+    }
+
+    fun chiudiDettaglio() {
+        _segnalazioneSelezionata.value = null
+    }
+
+    fun segnalaRisolta() {
+        // In realt\u00e0 dovremmo aggiornare il backend
+        _segnalazioneSelezionata.value = null
+    }
+}

--- a/app/src/main/java/it/quartierevivo/Segnalazione.kt
+++ b/app/src/main/java/it/quartierevivo/Segnalazione.kt
@@ -1,11 +1,16 @@
 package it.quartierevivo
 
 import android.net.Uri
+import com.google.android.gms.maps.model.LatLng
 
+/**
+ * Rappresenta una segnalazione inserita dagli utenti.
+ */
 data class Segnalazione(
     val titolo: String,
     val descrizione: String,
     val categoria: String,
     val fotoUri: Uri?,
-    val posizione: String?
+    val posizione: LatLng?,
+    val dataInvio: String
 )

--- a/app/src/main/java/it/quartierevivo/SegnalazioneScreen.kt
+++ b/app/src/main/java/it/quartierevivo/SegnalazioneScreen.kt
@@ -3,6 +3,7 @@ package it.quartierevivo
 import android.Manifest
 import android.net.Uri
 import android.widget.Toast
+import com.google.android.gms.maps.model.LatLng
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -50,8 +51,8 @@ fun SegnalazioneScreen(viewModel: SegnalazioneViewModel = viewModel()) {
 
     val locationPermissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
         if (granted) {
-            // Placeholder for real GPS retrieval
-            viewModel.onPosizioneChange("Lat:0, Lng:0")
+            // Placeholder per il recupero reale della posizione
+            viewModel.onPosizioneChange(LatLng(0.0, 0.0))
         } else {
             Toast.makeText(context, "Permesso posizione negato", Toast.LENGTH_SHORT).show()
         }

--- a/app/src/main/java/it/quartierevivo/SegnalazioneViewModel.kt
+++ b/app/src/main/java/it/quartierevivo/SegnalazioneViewModel.kt
@@ -1,6 +1,7 @@
 package it.quartierevivo
 
 import android.net.Uri
+import com.google.android.gms.maps.model.LatLng
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -15,7 +16,9 @@ class SegnalazioneViewModel : ViewModel() {
         private set
     var fotoUri by mutableStateOf<Uri?>(null)
         private set
-    var posizione by mutableStateOf<String?>(null)
+    var posizione by mutableStateOf<LatLng?>(null)
+        private set
+    var dataInvio by mutableStateOf("")
         private set
     var invioConfermato by mutableStateOf(false)
         private set
@@ -24,10 +27,12 @@ class SegnalazioneViewModel : ViewModel() {
     fun onDescrizioneChange(value: String) { descrizione = value }
     fun onCategoriaChange(value: String) { categoria = value }
     fun onFotoChange(uri: Uri?) { fotoUri = uri }
-    fun onPosizioneChange(value: String?) { posizione = value }
+    fun onPosizioneChange(value: LatLng?) { posizione = value }
+    fun onDataInvioChange(value: String) { dataInvio = value }
 
     fun inviaSegnalazione() {
         // Placeholder for actual send logic (e.g., Firebase)
+        dataInvio = java.text.SimpleDateFormat("dd/MM/yyyy").format(java.util.Date())
         invioConfermato = true
     }
 


### PR DESCRIPTION
## Summary
- espande il model `Segnalazione` con posizione e data di invio
- implementa `MappaSegnalazioniViewModel` e `MappaSegnalazioniScreen`
- aggiunge la composable `DettaglioSegnalazioneSheet`
- aggiorna `SegnalazioneViewModel` e `SegnalazioneScreen` per usare `LatLng`
- aggiunge dipendenze Google Maps, coil e maps-compose

## Testing
- `./gradlew build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687a80632b848323a75322809fdf1174